### PR TITLE
Add 'skipped' state to StateOrder mapping

### DIFF
--- a/src/task_spooler_gui/task_spooler_utils.py
+++ b/src/task_spooler_gui/task_spooler_utils.py
@@ -69,6 +69,7 @@ def list_jobs(socket_name=None):
         "running",
         "queued",
         "finished",
+        "skipped",
     ].index(x))
     df["IDOrder"] = df["ID"].apply(lambda x: int(x))
     # df = df.sort_values(by=["StateOrder", "IDOrder"])


### PR DESCRIPTION
The GUI just crashes if any task has the "skipped" state.